### PR TITLE
Remove RE2 for compatibility with Workers Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,16 @@
 # Email Forward Parser
 
-[![Test and Build](https://github.com/crisp-oss/email-forward-parser/workflows/Test%20and%20Build/badge.svg?branch=master)](https://github.com/crisp-oss/email-forward-parser/actions?query=workflow%3A%22Test+and+Build%22) [![Build and Release](https://github.com/crisp-oss/email-forward-parser/workflows/Build%20and%20Release/badge.svg)](https://github.com/crisp-oss/email-forward-parser/actions?query=workflow%3A%22Build+and+Release%22) [![NPM](https://img.shields.io/npm/v/email-forward-parser.svg)](https://www.npmjs.com/package/email-forward-parser) [![Downloads](https://img.shields.io/npm/dt/email-forward-parser.svg)](https://www.npmjs.com/package/email-forward-parser)
+[![Test and Build](https://github.com/ch4nn0n/email-forward-parser/workflows/Test%20and%20Build/badge.svg?branch=master)](https://github.com/ch4nn0n/email-forward-parser/actions?query=workflow%3A%22Test+and+Build%22) [![Build and Release](https://github.com/ch4nn0n/email-forward-parser/workflows/Build%20and%20Release/badge.svg)](https://github.com/ch4nn0n/email-forward-parser/actions?query=workflow%3A%22Build+and+Release%22) [![NPM](https://img.shields.io/npm/v/@ch4nn0n/email-forward-parser.svg)](https://www.npmjs.com/package/@channon/email-forward-parser) [![Downloads](https://img.shields.io/npm/dt/@channon/email-forward-parser.svg)](https://www.npmjs.com/package/@channon/email-forward-parser)
 
 Parses forwarded emails and extracts original content.
 
 This library supports most common email clients and locales.
 
-**😘 Maintainer**: [@eliottvincent](https://github.com/eliottvincent)
-
-## Who uses it?
-
-<table>
-<tr>
-<td align="center"><a href="https://crisp.chat/"><img src="https://crisp.chat/favicon-256x256.png" height="64" /></a></td>
-</tr>
-<tr>
-<td align="center">Crisp</td>
-</tr>
-</table>
-
-_👋 You use this library and you want to be listed there? [Contact us](https://crisp.chat/)._
+## Motivation
+The original project from [Crisp](https://crisp.chat/) [email-reply-parser](https://github.com/crisp-oss/email-forward-parser) relies on the [RE2](https://www.npmjs.com/package/re2) library, which is not available on all platforms, namely some serverless and browser environments. This fork is a pure javascript implementation of the same library.  
 
 ## Features
 
-This library is used at [Crisp](https://crisp.chat/) everyday with around 1 million inbound emails.
 * Supported clients: Apple Mail, Gmail, Outlook Live / 365, Outlook 2013, Outlook 2019, New Outlook 2019, Yahoo Mail, Thunderbird, Missive, HubSpot, IONOS by 1 & 1
 * Supported locales: Croatian, Czech, Danish, Dutch, English, French, Finnish, German, Hungarian, Italian, Japanese, Norwegian, Polish, Portuguese (Brazil), Portuguese (Portugal), Romanian, Russian, Slovak, Spanish, Swedish, Turkish, Ukrainian
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,6 @@
 "use strict";
 
 
-var RE2                                                 = require("re2");
 var { loopRegexes, reconciliateSplitMatch, trimString } = require("./utils");
 
 
@@ -584,7 +583,7 @@ class Parser {
           }
 
           this.__regexes[_key].push(
-            new RE2(_regex)
+            new RegExp(_regex)
           );
         }
       } else {
@@ -597,7 +596,7 @@ class Parser {
           this.__regexes[_key_line] = _regex_line;
         }
 
-        this.__regexes[_key] = new RE2(_regex);
+        this.__regexes[_key] = new RegExp(_regex);
       }
     }
   }
@@ -619,7 +618,7 @@ class Parser {
     var _source = `(${regex.source})`;
     var _flags  = regex.flags;
 
-    return new RE2(_source, _flags);
+    return new RegExp(_source, _flags);
   }
 
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,12 +1,6 @@
 "use strict";
 
 /**************************************************************************
- * IMPORTS
- ***************************************************************************/
-
-var RE2 = require("re2");
-
-/**************************************************************************
  * FUNCTIONS
  ***************************************************************************/
 
@@ -29,11 +23,12 @@ var loopRegexes = function(
 
     if (typeof regexes[_i] === "string") {
       // Build the regex
-      _regex = new RE2(regexes[_i]);
+      _regex = new RegExp(regexes[_i]);
     }
 
-    var _currentMatch = (
-      _regex[mode](str || "", mode === "replace" ? "" : undefined)
+    var _currentMatch = (str || "")[mode](
+        _regex,
+        mode === "replace" ? "" : undefined
     );
 
     if (mode === "replace") {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
   "devDependencies": {
     "nodeunit-x": "0.15.0"
   },
-  "dependencies": {
-    "re2": "1.18.0"
-  },
   "keywords": [
     "parser",
     "mail",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "email-forward-parser",
-  "version": "1.4.2",
+  "name": "@ch4nn0n/email-forward-parser",
+  "version": "1.5.0",
   "description": "Parses forwarded emails and extract content",
   "author": "Eliott Vincent <eliott@crisp.chat>",
   "main": "lib/index.js",


### PR DESCRIPTION
The current implementation of email-forward-parser is not compatible with some serverless runtimes such as Cloudflare Workers and in browser environments. Replacing RE2 with the standard RegExp will allow this to be used in other environments.